### PR TITLE
fix: fix 'Attempted import error' in 'react-native-reanimated'

### DIFF
--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -7,11 +7,7 @@ import {
   InteractionManager,
 } from 'react-native';
 import { PanGestureHandler, State } from 'react-native-gesture-handler';
-import Animated, {
-  Easing as OldEasing,
-  // @ts-ignore
-  EasingNode,
-} from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 import memoize from './memoize';
 
 import {
@@ -25,7 +21,8 @@ import {
 
 type Binary = 0 | 1;
 
-const Easing = EasingNode || OldEasing;
+// @ts-ignore
+const Easing = Animated.EasingNode || Animated.Easing;
 
 export type Props<T extends Route> = PagerCommonProps & {
   onIndexChange: (index: number) => void;

--- a/src/TabBarIndicator.tsx
+++ b/src/TabBarIndicator.tsx
@@ -1,15 +1,12 @@
 import * as React from 'react';
 import { StyleSheet, I18nManager, StyleProp, ViewStyle } from 'react-native';
-import Animated, {
-  Easing as OldEasing,
-  // @ts-ignore
-  EasingNode,
-} from 'react-native-reanimated';
+import Animated from 'react-native-reanimated';
 
 import memoize from './memoize';
 import { Route, SceneRendererProps, NavigationState } from './types';
 
-const Easing = EasingNode || OldEasing;
+// @ts-ignore
+const Easing = Animated.EasingNode || Animated.Easing;
 
 export type GetTabWidth = (index: number) => number;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5440840/93356197-d8c8f000-f879-11ea-8e63-75323321e779.png)

./node_modules/react-native-tab-view/lib/module/TabBarIndicator.js
Attempted import error: 'EasingNode' is not exported from 'react-native-reanimated'.

an error occurred in react-native-web + nextjs