### PR TITLE
Collapsible Header With Tab View

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -23,6 +23,7 @@ import TabBarIconExample from './TabBarIconExample';
 import CustomIndicatorExample from './CustomIndicatorExample';
 import CustomTabBarExample from './CustomTabBarExample';
 import CoverflowExample from './CoverflowExample';
+import CollapsibleHeaderExample from './CollapsibleHeaderExample';
 
 type State = {
   title: string;
@@ -51,6 +52,7 @@ const EXAMPLE_COMPONENTS: ExampleComponentType[] = [
   CustomIndicatorExample,
   CustomTabBarExample,
   CoverflowExample,
+  CollapsibleHeaderExample,
 ];
 
 const KeepAwake = () => {
@@ -235,6 +237,7 @@ const styles = StyleSheet.create({
   },
   appbar: {
     borderBottomColor: 'rgba(0, 0, 0, 0.1)',
+    zIndex: 1, // Needed for keeping the screen header above the collapsible tab view header
   },
   content: {
     flexDirection: 'row',

--- a/example/src/CollapsibleHeaderExample.tsx
+++ b/example/src/CollapsibleHeaderExample.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import {
+  TabBar,
+  NavigationState,
+  SceneRendererProps,
+} from 'react-native-tab-view';
+import Article from './Shared/Article';
+import Albums from './Shared/Albums';
+import Contacts from './Shared/Contacts';
+
+import CollapsibleHeader from '../../src/CollapsibleHeader';
+
+type State = NavigationState<{
+  key: string;
+  title: string;
+}>;
+
+// These must be hardcoded to support the various animations needed for the effect
+const HEADER_HEIGHT = 144;
+const TAB_BAR_HEIGHT = 48;
+
+export default class CollapsibleHeaderExample extends React.Component<
+  {},
+  State
+> {
+  // eslint-disable-next-line react/sort-comp
+  static title = 'Collapsible header tab bar';
+  static backgroundColor = '#3f51b5';
+  static appbarElevation = 0;
+
+  state = {
+    index: 1,
+    routes: [
+      { key: 'article', title: 'Article' },
+      { key: 'contacts', title: 'Contacts' },
+      { key: 'albums', title: 'Albums' },
+    ],
+  };
+
+  private handleIndexChange = (index: number) =>
+    this.setState({
+      index,
+    });
+
+  private renderTabBar = (
+    props: SceneRendererProps & { navigationState: State }
+  ) => (
+    <TabBar
+      {...props}
+      scrollEnabled
+      indicatorStyle={styles.indicator}
+      style={styles.tabbar}
+      tabStyle={styles.tab}
+      labelStyle={styles.label}
+    />
+  );
+
+  render() {
+    return (
+      <CollapsibleHeader
+        // This is dummy data, we render the entire content as a single component for both tabs
+        // TODO: Create an example which explains why we do it this way, by showing proper use of the underlying FlatList
+        tabData={[[{ key: '0' }], [{ key: '1' }], [{ key: '2' }]]}
+        tabBarHeight={TAB_BAR_HEIGHT}
+        headerHeight={HEADER_HEIGHT}
+        renderTabItems={[
+          this.renderTabOne,
+          this.renderTabTwo,
+          this.renderTabThree,
+        ]}
+        renderHeader={this.renderHeader}
+        renderTabBar={this.renderTabBar}
+        onIndexChange={this.handleIndexChange}
+        navigationState={this.state}
+      />
+    );
+  }
+
+  renderTabOne = () => <Albums />;
+
+  renderTabTwo = () => <Contacts />;
+
+  renderTabThree = () => <Article />;
+
+  renderHeader = () => (
+    <View style={styles.headerRow}>
+      <View style={styles.headerCol}>
+        <Text style={styles.text}>Collapsible Header</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  tabbar: {
+    backgroundColor: '#3f51b5',
+  },
+  tab: {
+    width: 120,
+  },
+  indicator: {
+    backgroundColor: '#ffeb3b',
+  },
+  label: {
+    fontWeight: '400',
+  },
+  headerRow: {
+    height: HEADER_HEIGHT,
+    flexDirection: 'row',
+    backgroundColor: '#429BB8',
+  },
+  headerCol: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  text: {
+    textAlign: 'center',
+    fontSize: 24,
+  },
+});

--- a/src/CollapsibleHeader.tsx
+++ b/src/CollapsibleHeader.tsx
@@ -1,0 +1,245 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  Animated,
+  Dimensions,
+  SafeAreaView,
+  StyleSheet,
+  View,
+  FlatListProps,
+  ListRenderItem,
+} from 'react-native';
+
+import TabView from './TabView';
+
+interface Props {
+  renderTabItems: (ListRenderItem<any> | null | undefined)[];
+  tabBarHeight: number;
+  headerHeight: number;
+  onIndexChange: (index: number) => void;
+  navigationState: any;
+  renderHeader: React.FunctionComponent;
+  renderTabBar: any;
+  tabData: object[][];
+  tabViewProps?: object;
+  flatListProps?: Partial<FlatListProps<any>>[];
+}
+
+const CollapsibleHeader = (props: Props) => {
+  const {
+    renderTabItems,
+    tabBarHeight,
+    headerHeight,
+    onIndexChange,
+    navigationState,
+    renderHeader,
+    renderTabBar,
+    tabData,
+    tabViewProps = {},
+    flatListProps,
+  } = props;
+
+  const { routes, index: tabIndex } = navigationState;
+
+  const scrollY = useRef<any>(new Animated.Value(0)).current;
+  const listRefArr = useRef<any[]>([]);
+  const listOffset = useRef<any>({});
+  const isListGliding = useRef<boolean>(false);
+
+  useEffect(() => {
+    scrollY.addListener(({ value }: any) => {
+      const curRoute = routes[tabIndex].key;
+      listOffset.current[curRoute] = value;
+    });
+    return () => {
+      scrollY.removeAllListeners();
+    };
+  }, [routes, scrollY, tabIndex]);
+
+  const syncScrollOffset = () => {
+    const curRouteKey = routes[tabIndex].key;
+    listRefArr.current.forEach((item) => {
+      if (item.key === curRouteKey) {
+        return;
+      }
+
+      if (scrollY._value < headerHeight && scrollY._value >= 0) {
+        if (item.value) {
+          item.value.scrollToOffset({
+            offset: scrollY._value,
+            animated: false,
+          });
+          listOffset.current[item.key] = scrollY._value;
+        }
+      } else if (
+        scrollY._value >= headerHeight &&
+        (listOffset.current[item.key] < headerHeight ||
+          listOffset.current[item.key] == null) &&
+        item.value
+      ) {
+        item.value.scrollToOffset({
+          offset: headerHeight,
+          animated: false,
+        });
+        listOffset.current[item.key] = headerHeight;
+      }
+    });
+  };
+
+  const onMomentumScrollBegin = () => {
+    isListGliding.current = true;
+  };
+
+  const onMomentumScrollEnd = () => {
+    isListGliding.current = false;
+    syncScrollOffset();
+  };
+
+  const onScrollEndDrag = () => {
+    syncScrollOffset();
+  };
+
+  const renderScene = ({ route }: any) => {
+    const index = navigationState.routes.findIndex(
+      ({ key }: { key: string }) => key === route.key
+    );
+
+    const renderItem = renderTabItems[index];
+    const data = tabData[index];
+    const flatListPropsForTab = flatListProps?.[index];
+
+    const windowHeight = Dimensions.get('window').height;
+
+    const contentContainerStyle = {
+      paddingTop: headerHeight,
+      minHeight: windowHeight - tabBarHeight,
+    };
+
+    return (
+      <>
+        {/* Since TabBar is absolute positioned, we need to add space so push content down below it. Don't use FlatList padding as that breaks stickyHeaders */}
+        <View style={{ height: tabBarHeight }} />
+        <Animated.FlatList
+          scrollToOverflowEnabled
+          scrollEventThrottle={16}
+          onScroll={Animated.event(
+            [{ nativeEvent: { contentOffset: { y: scrollY } } }],
+            { useNativeDriver: true }
+          )}
+          onMomentumScrollBegin={onMomentumScrollBegin}
+          onScrollEndDrag={onScrollEndDrag}
+          onMomentumScrollEnd={onMomentumScrollEnd}
+          contentContainerStyle={contentContainerStyle}
+          data={data}
+          ref={(ref: any) => {
+            if (ref) {
+              const found = listRefArr.current.find((e) => e.key === route.key);
+              if (!found) {
+                listRefArr.current.push({
+                  key: route.key,
+                  value: ref,
+                });
+              }
+            }
+          }}
+          renderItem={renderItem}
+          showsVerticalScrollIndicator={false}
+          showsHorizontalScrollIndicator={false}
+          decelerationRate="fast" // Since we prevent switching tabs during momentum, we want it to decelerate faster
+          {...flatListPropsForTab}
+        />
+      </>
+    );
+  };
+
+  const renderTabBarWithWrapper = (innerProps: any) => {
+    const y = scrollY.interpolate({
+      inputRange: [0, headerHeight],
+      outputRange: [headerHeight, 0],
+      extrapolateRight: 'clamp',
+    });
+
+    const propsToPass = {
+      onTabPress: ({ preventDefault }: any) => {
+        if (isListGliding.current) {
+          preventDefault();
+        }
+      },
+      ...innerProps,
+    };
+
+    const viewStyles = {
+      top: 0,
+      zIndex: 1,
+      position: 'absolute' as 'absolute',
+      transform: [{ translateY: y }],
+      width: '100%',
+    };
+
+    return (
+      <Animated.View style={viewStyles}>
+        {renderTabBar(propsToPass)}
+      </Animated.View>
+    );
+  };
+
+  const renderTabView = () => {
+    return (
+      <TabView
+        onIndexChange={onIndexChange}
+        navigationState={navigationState}
+        renderScene={renderScene}
+        renderTabBar={renderTabBarWithWrapper}
+        initialLayout={{
+          height: 0,
+          width: Dimensions.get('window').width,
+        }}
+        {...tabViewProps}
+      />
+    );
+  };
+
+  const renderHeaderWithWrapper = () => {
+    const y = scrollY.interpolate({
+      inputRange: [0, headerHeight],
+      outputRange: [0, -headerHeight],
+      extrapolateRight: 'clamp',
+    });
+
+    return (
+      <Animated.View
+        style={[
+          localStyles.header,
+          { height: headerHeight },
+          { transform: [{ translateY: y }] },
+        ]}
+      >
+        {renderHeader({})}
+      </Animated.View>
+    );
+  };
+
+  return (
+    <SafeAreaView style={localStyles.flex1}>
+      <View style={localStyles.flex1}>
+        {renderTabView()}
+        {renderHeaderWithWrapper()}
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const localStyles = StyleSheet.create({
+  header: {
+    top: 0,
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'absolute',
+    zIndex: -1,
+  },
+  flex1: {
+    flex: 1,
+  },
+});
+
+export default CollapsibleHeader;


### PR DESCRIPTION
### Motivation

The UI of having a collapsible header above a Tab View is a commonly requested pattern (#411), but it is surprisingly challenging for newer RN devs to implement. Creating a wrapper for this functionality and some examples for using the wrapper will help allow them to have a baseline for how to add this pattern into their own apps.

#### Prior Examples

@satya164 Provided https://snack.expo.io/@satya164/collapsible-header-with-tabview as an example. It's a valuable start for understanding how to work on this, but the snack itself can't be used without significant additional work due to the additional of large amounts of padding above the content when switching tabs in certain cases #441.

[This example](https://blog.expo.io/implementation-complex-animation-in-react-native-by-example-search-bar-with-tab-view-and-collapsing-68bb43be2dcb) appears to be complete, but it's a rather larger example that is challenging to quickly bring into a different projects that just wants the minimum code needed to reproduce the baseline effect.

@JungHsuan Provided a [medium article](https://medium.com/@linjunghsuan/implementing-a-collapsible-header-with-react-native-tab-view-24f15a685e07) on his approach, which was practically production ready and had the exact UI flow that was buttery smooth and consistent in all cases. I started with this approach, and converted it into something more re-usable in different situations, trying to make it quicker for other developers to pull into their projects.

### UI Animation

![Sep-26-2020 13-36-27](https://user-images.githubusercontent.com/14143246/94348915-67b5d500-fffd-11ea-8032-df1775849d63.gif)

### Current known limitations/issues

1. Since the collapsible header view becomes absolutely positioned and is animated, you'll need to adjust `zIndex` of the headers above it (see example code)

1. In order to support scrolling the `TabBar` up, we must set a minimum height for the scrollable content. If you have one tab with only a small amount of content in there, it will be allowed to scroll up with large padding below it. This maybe be possible fix via measuring the content, but that would be an enhancement. Edit: Discussed possible fix [here](https://github.com/JungHsuan/react-native-collapsible-tabview/issues/9#issuecomment-699583993).

1. The `CollapsibleHeader` `prop` structure I initially proposed may not be ideal. It basically forces use to create an array of `renderItem` and `data`, which is used by each tab separately to draw its content. But the idea behind this even for non-virtualized content, we need a `ScrollView` or `FlatList` wrapper in there to drive this behavior, so we want to bake this functionality into the wrapper while still making implementation lightweight. This also has the side effect of fully supporting both tab content that are rendered at once, or using `FlatList` virtualized rendering.

1. I attempted to use `SectionList` to drive this, but challenges with measuring scroll distances shut down my early attempts.

1. If you scroll tab 1 all the way down, swap to tab 2, scroll it up any amount, and come back to tab 1, you'll notice tab 1 is now at the top, with the collapsible header being set at the same height. This isn't a real 'limitation' as it's simply necessary for the UI to be smooth, but it's good to be aware of.

### Test plan

This is an early draft version of the PR. I am submitting in this state to see if there is interest in me polishing it up.

TODO's:
- [ ] Stricter typings (I used `any` in many places where it can be better typed)
- [ ] Removal of inline functions
- [ ] Adding example of correctly using underlying `FlatList`
- [ ] There is some warning spam right now that needs to be cleaned up