### PR TITLE
fix: fix `TabBarIndicator` width props type

### DIFF
--- a/src/TabBarIndicator.tsx
+++ b/src/TabBarIndicator.tsx
@@ -15,7 +15,7 @@ export type GetTabWidth = (index: number) => number;
 
 export type Props<T extends Route> = SceneRendererProps & {
   navigationState: NavigationState<T>;
-  width: string;
+  width: string | number;
   style?: StyleProp<ViewStyle>;
   getTabWidth: GetTabWidth;
 };


### PR DESCRIPTION
Following the implementation https://github.com/satya164/react-native-tab-view/blob/master/src/TabBarIndicator.tsx#L123
width can be a string or a number.
