### PR TITLE
fix: avoid loading next tab on tab mount (ios)

### DIFF
--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -601,11 +601,11 @@ export default class Pager<T extends Route> extends React.Component<
           ? lessThan(this.gestureX, 0)
           : greaterThan(this.gestureX, 0),
         // Based on the direction of the gesture, determine if we're entering the previous or next screen
-        cond(neq(floor(this.position), this.lastEnteredIndex), [
+        cond(and(neq(floor(this.position), this.lastEnteredIndex), neq(this.position, this.lastEnteredIndex)), [
           set(this.lastEnteredIndex, floor(this.position)),
           call([floor(this.position)], this.handleEnteredIndexChange),
         ]),
-        cond(neq(ceil(this.position), this.lastEnteredIndex), [
+        cond(and(neq(ceil(this.position), this.lastEnteredIndex), neq(this.position, this.lastEnteredIndex)), [
           set(this.lastEnteredIndex, ceil(this.position)),
           call([ceil(this.position)], this.handleEnteredIndexChange),
         ])


### PR DESCRIPTION
### Motivation

I noticed that my 2nd tab was preloading (although in lazy=true + lazyPreloadDistance=0) on iOS on component mount
With further investigation, I noticed that the listener of 'enter' was called with a value wrongly rounded: `ceil(2.000000) = 3`

### Test plan

Simply tested again on iOS simulator, navigating between 2/3 tabs

I did **not** try to change props to explore other use cases (disabling lazy, or changing lazyPreloadDistance)
