### PR TITLE
fix: TabBar with scrollEnable to take into consideration the content margins

### DIFF
--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -148,6 +148,33 @@ export default class TabBar<T extends Route> extends React.Component<
     return tabStyle ? tabStyle.width : undefined;
   };
 
+  //
+  // when calculating the scroll distance, take into consideration also any spacing from the container 
+  //
+  private getComputedContentSpacing = (style: StyleProp<ViewStyle>) => {
+    const contentStyle = StyleSheet.flatten(style);
+
+    let space = 0;
+    
+    if(typeof contentStyle.marginLeft === 'number'){
+      space += contentStyle.marginLeft;
+    }
+
+    if(typeof contentStyle.marginRight === 'number'){
+      space += contentStyle.marginRight;
+    }
+
+    if(typeof contentStyle.paddingLeft === 'number'){
+      space += contentStyle.paddingLeft;
+    }
+
+    if(typeof contentStyle.paddingRight === 'number'){
+      space += contentStyle.paddingRight;
+    }
+
+    return space;
+  };
+
   private getComputedTabWidth = (
     index: number,
     layout: Layout,
@@ -202,7 +229,7 @@ export default class TabBar<T extends Route> extends React.Component<
 
   private getTabBarWidth = (props: Props<T>, state: State) => {
     const { layout, tabWidths } = state;
-    const { scrollEnabled, tabStyle } = props;
+    const { scrollEnabled, tabStyle, contentContainerStyle } = props;
     const { routes } = props.navigationState;
 
     return routes.reduce<number>(
@@ -216,7 +243,7 @@ export default class TabBar<T extends Route> extends React.Component<
           tabWidths,
           this.getFlattenedTabWidth(tabStyle)
         ),
-      0
+      this.getComputedContentSpacing(contentContainerStyle)
     );
   };
 

--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -149,26 +149,26 @@ export default class TabBar<T extends Route> extends React.Component<
   };
 
   //
-  // when calculating the scroll distance, take into consideration also any spacing from the container 
+  // when calculating the scroll distance, take into consideration also any spacing from the container
   //
-  private getComputedContentSpacing = (style: StyleProp<ViewStyle>) => {
+  private getComputedContentSpacing = (style?: StyleProp<ViewStyle>) => {
     const contentStyle = StyleSheet.flatten(style);
 
     let space = 0;
-    
-    if(typeof contentStyle.marginLeft === 'number'){
+
+    if (typeof contentStyle?.marginLeft === 'number') {
       space += contentStyle.marginLeft;
     }
 
-    if(typeof contentStyle.marginRight === 'number'){
+    if (typeof contentStyle?.marginRight === 'number') {
       space += contentStyle.marginRight;
     }
 
-    if(typeof contentStyle.paddingLeft === 'number'){
+    if (typeof contentStyle?.paddingLeft === 'number') {
       space += contentStyle.paddingLeft;
     }
 
-    if(typeof contentStyle.paddingRight === 'number'){
+    if (typeof contentStyle?.paddingRight === 'number') {
       space += contentStyle.paddingRight;
     }
 


### PR DESCRIPTION
If you want to use a custom TabBar like

```
<TabBar
      {...tabBarProps}
      scrollEnabled={true}
      contentContainerStyle={{marginLeft: 14}}
/>
```

currently, the last tab will be cut with 14px, as it does not take into consideration these kind of spacing.

This PR fixes that.


### Motivation

The last tab item is cut with with the amount you put as padding / margin to the contentContainer.

### Test plan

Let me know if you need any screenshots, but should be straitforward
