### PR TITLE
fix: moved color to last prop

### DIFF
--- a/src/TabBarItem.tsx
+++ b/src/TabBarItem.tsx
@@ -159,8 +159,8 @@ export default class TabBarItem<T extends Route> extends React.Component<
                   style={[
                     styles.label,
                     icon ? { marginTop: 0 } : null,
-                    { color },
                     labelStyle,
+                    { color },
                   ]}
                 >
                   {labelText}


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

For tabbar labels I want to add styles and either active or inactive color.  The assumption is that the color prop would override the style prop.  

