### PR TITLE
feat: add tabBarSpacing property

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,10 @@ Style to apply to the inner container for tabs.
 
 Style to apply to the tab bar container.
 
+### `gap`
+
+Define a spacing between tabs.
+
 ## Using with other libraries
 
 ### [React Navigation](https://github.com/react-navigation/react-navigation)

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -21,6 +21,7 @@ import TabBarIconExample from './TabBarIconExample';
 import CustomIndicatorExample from './CustomIndicatorExample';
 import CustomTabBarExample from './CustomTabBarExample';
 import CoverflowExample from './CoverflowExample';
+import TabBarGapExample from './TabBarGapExample';
 
 type State = {
   title: string;
@@ -47,6 +48,7 @@ const EXAMPLE_COMPONENTS: ExampleComponentType[] = [
   CustomIndicatorExample,
   CustomTabBarExample,
   CoverflowExample,
+  TabBarGapExample,
 ];
 
 const KeepAwake = () => {

--- a/example/src/TabBarGapExample.tsx
+++ b/example/src/TabBarGapExample.tsx
@@ -1,0 +1,88 @@
+import * as React from 'react';
+import { StyleSheet } from 'react-native';
+import {
+  TabView,
+  TabBar,
+  SceneMap,
+  NavigationState,
+  SceneRendererProps,
+} from 'react-native-tab-view';
+import Article from './Shared/Article';
+import Albums from './Shared/Albums';
+import Chat from './Shared/Chat';
+import Contacts from './Shared/Contacts';
+
+type State = NavigationState<{
+  key: string;
+  title: string;
+}>;
+
+export default class TabBarGapExample extends React.Component<{}, State> {
+  // eslint-disable-next-line react/sort-comp
+  static title = 'Tab bar gap';
+  static backgroundColor = '#3f51b5';
+  static appbarElevation = 0;
+
+  state = {
+    index: 1,
+    routes: [
+      { key: 'article', title: 'Article' },
+      { key: 'contacts', title: 'Contacts' },
+      { key: 'albums', title: 'Albums' },
+      { key: 'chat', title: 'Chat ' },
+    ],
+  };
+
+  private handleIndexChange = (index: number) =>
+    this.setState({
+      index,
+    });
+
+  private renderTabBar = (
+    props: SceneRendererProps & { navigationState: State }
+  ) => (
+    <TabBar
+      {...props}
+      scrollEnabled
+      indicatorStyle={styles.indicator}
+      style={styles.tabbar}
+      tabStyle={styles.tab}
+      labelStyle={styles.label}
+      gap={40}
+    />
+  );
+
+  private renderScene = SceneMap({
+    albums: Albums,
+    contacts: Contacts,
+    article: Article,
+    chat: Chat,
+  });
+
+  render() {
+    return (
+      <TabView
+        lazy
+        navigationState={this.state}
+        renderScene={this.renderScene}
+        renderTabBar={this.renderTabBar}
+        onIndexChange={this.handleIndexChange}
+      />
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  tabbar: {
+    backgroundColor: '#3f51b5',
+  },
+  tab: {
+    width: 'auto',
+  },
+  indicator: {
+    backgroundColor: '#ffeb3b',
+  },
+  label: {
+    fontWeight: '400',
+  },
+});

--- a/src/TabBarIndicator.tsx
+++ b/src/TabBarIndicator.tsx
@@ -18,6 +18,7 @@ export type Props<T extends Route> = SceneRendererProps & {
   width: string | number;
   style?: StyleProp<ViewStyle>;
   getTabWidth: GetTabWidth;
+  gap?: number;
 };
 
 export default class TabBarIndicator<T extends Route> extends React.Component<
@@ -59,14 +60,15 @@ export default class TabBarIndicator<T extends Route> extends React.Component<
   private getTranslateX = (
     position: Animated.AnimatedInterpolation,
     routes: Route[],
-    getTabWidth: GetTabWidth
+    getTabWidth: GetTabWidth,
+    gap?: number
   ) => {
     const inputRange = routes.map((_, i) => i);
 
     // every index contains widths at all previous indices
     const outputRange = routes.reduce<number[]>((acc, _, i) => {
       if (i === 0) return [0];
-      return [...acc, acc[i - 1] + getTabWidth(i - 1)];
+      return [...acc, acc[i - 1] + getTabWidth(i - 1) + (gap ?? 0)];
     }, []);
 
     const translateX = position.interpolate({
@@ -79,8 +81,15 @@ export default class TabBarIndicator<T extends Route> extends React.Component<
   };
 
   render() {
-    const { position, navigationState, getTabWidth, width, style, layout } =
-      this.props;
+    const {
+      position,
+      navigationState,
+      getTabWidth,
+      width,
+      style,
+      layout,
+      gap,
+    } = this.props;
     const { routes } = navigationState;
 
     const transform = [];
@@ -88,7 +97,7 @@ export default class TabBarIndicator<T extends Route> extends React.Component<
     if (layout.width) {
       const translateX =
         routes.length > 1
-          ? this.getTranslateX(position, routes, getTabWidth)
+          ? this.getTranslateX(position, routes, getTabWidth, gap)
           : 0;
 
       transform.push({ translateX });


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

The goal is to support spacing between tabs ( see #1020 ) - It is roughly doable with some customizations (thanks to `renderTabBarItem` and `renderIndicator` methods) but it requires to modify internal methods (`getTranslateX` for example)  

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

I have added one example ( `TabBarSpacingExample` ) 
