### PR TITLE
Hide invisible tabs content (by setting their height to 0)

### DIFF
--- a/src/SceneView.tsx
+++ b/src/SceneView.tsx
@@ -15,6 +15,7 @@ type Props<T extends Route> = SceneRendererProps &
     index: number;
     children: (props: { loading: boolean }) => React.ReactNode;
     style?: StyleProp<ViewStyle>;
+    isSwiping: boolean;
   };
 
 type State = {
@@ -92,7 +93,7 @@ export default class SceneView<T extends Route> extends React.Component<
   };
 
   render() {
-    const { navigationState, index, layout, style } = this.props;
+    const { navigationState, index, layout, style, isSwiping } = this.props;
     const { loading } = this.state;
 
     const focused = navigationState.index === index;
@@ -111,6 +112,7 @@ export default class SceneView<T extends Route> extends React.Component<
             ? StyleSheet.absoluteFill
             : null,
           style,
+          focused || isSwiping? null: {height: 0},
         ]}
       >
         {

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -124,6 +124,7 @@ export default function TabView<T extends Route>({
                       lazyPreloadDistance={lazyPreloadDistance}
                       navigationState={navigationState}
                       style={sceneContainerStyle}
+                      isSwiping={isSwiping}
                     >
                       {({ loading }) =>
                         loading

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -50,6 +50,7 @@ export default function TabView<T extends Route>({
   swipeEnabled = true,
   tabBarPosition = 'top',
 }: Props<T>) {
+  const [isSwiping, setIsSwiping] = React.useState(false);
   const [layout, setLayout] = React.useState({
     width: 0,
     height: 0,
@@ -74,6 +75,16 @@ export default function TabView<T extends Route>({
     });
   };
 
+  const swipeStart = () => {
+    setIsSwiping(true);
+    onSwipeStart?.();
+  }
+
+  const swipeEnd = () => {
+    setIsSwiping(false);
+    onSwipeEnd?.();
+  }
+
   return (
     <View onLayout={handleLayout} style={[styles.pager, style]}>
       <Pager
@@ -81,8 +92,8 @@ export default function TabView<T extends Route>({
         navigationState={navigationState}
         keyboardDismissMode={keyboardDismissMode}
         swipeEnabled={swipeEnabled}
-        onSwipeStart={onSwipeStart}
-        onSwipeEnd={onSwipeEnd}
+        onSwipeStart={swipeStart}
+        onSwipeEnd={swipeEnd}
         onIndexChange={jumpToIndex}
       >
         {({ position, render, addEnterListener, jumpTo }) => {


### PR DESCRIPTION
There is empty space on bottom of tab's scene, if other tabs height is larger than current tab

### Motivation

Fix #290 
In this PR I hide other tabs content (by setting their contents height to 0) to resolve this problem


### Test plan

- Add 3 tabs with different content height
- Switch between tabs
- Each tabs height is same as its contents height
