### PR TITLE
fix: Tab view height auto expand

### DIFF
--- a/src/SceneView.tsx
+++ b/src/SceneView.tsx
@@ -14,7 +14,7 @@ type Props<T extends Route> = SceneRendererProps &
     lazyPreloadDistance: number;
     index: number;
     children: (props: { loading: boolean }) => React.ReactNode;
-    style?: StyleProp<ViewStyle>;
+    containerStyle?: StyleProp<ViewStyle>;
   };
 
 type State = {
@@ -92,7 +92,7 @@ export default class SceneView<T extends Route> extends React.Component<
   };
 
   render() {
-    const { navigationState, index, layout, style } = this.props;
+    const { navigationState, index, layout, containerStyle } = this.props;
     const { loading } = this.state;
 
     const focused = navigationState.index === index;
@@ -110,7 +110,7 @@ export default class SceneView<T extends Route> extends React.Component<
             : focused
             ? StyleSheet.absoluteFill
             : null,
-          style,
+          containerStyle,
         ]}
       >
         {

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -112,7 +112,7 @@ export default function TabView<T extends Route>({
                       lazy={typeof lazy === 'function' ? lazy({ route }) : lazy}
                       lazyPreloadDistance={lazyPreloadDistance}
                       navigationState={navigationState}
-                      style={sceneContainerStyle}
+                      containerStyle={sceneContainerStyle}
                     >
                       {({ loading }) =>
                         loading


### PR DESCRIPTION
### Motivation

TabView's height does not expand anymore to the content size in version 3

A different approach would be to refactor `SceneView` component to be a functional component

Resolves: #1178