### PR TITLE
[web]: updating currentIndexRef when tab is switched by clicking tab bar

### DIFF
--- a/src/Pager.tsx
+++ b/src/Pager.tsx
@@ -117,6 +117,7 @@ export default function Pager<T extends Route>({
     }
 
     if (layout.width && currentIndexRef.current !== index) {
+      currentIndexRef.current = index;
       jumpToIndex(index);
     }
   }, [jumpToIndex, keyboardDismissMode, layout.width, index]);


### PR DESCRIPTION
There's a minor bug in web version of tabview. `currentIndexRef` in Pager.tsx file is only updated when tabs are switched using gesture. When they are switched using tab bar, you can not navigate back to tab which was mounted first.

Steps to reproduce:
Create a tabview with 3 tabs. Let say initial navigationState is { index: 0, title: 'abc' }. 
Now switch to any of the other 2 tabs
Now try to switch to 1st tab . It won't switch

Please note that gesture is not being used. `navigationState` is being updated and passed to TabView. In case of gesture it works correctly.
