### PR TITLE
fix: add pager initial index ref

### DIFF
--- a/src/PagerViewAdapter.tsx
+++ b/src/PagerViewAdapter.tsx
@@ -49,6 +49,7 @@ export default function PagerViewAdapter<T extends Route>({
 
   const pagerRef = React.useRef<ViewPager>();
   const indexRef = React.useRef<number>(index);
+  const initialIndexRef = React.useRef<number>(index);
   const navigationStateRef = React.useRef(navigationState);
 
   const position = useAnimatedValue(index);
@@ -124,7 +125,7 @@ export default function PagerViewAdapter<T extends Route>({
         {...rest}
         ref={pagerRef}
         style={[styles.container, style]}
-        initialPage={index}
+        initialPage={initialIndexRef.current}
         keyboardDismissMode={
           keyboardDismissMode === 'auto' ? 'on-drag' : keyboardDismissMode
         }


### PR DESCRIPTION
Pager `initialPage` prop was set to the current index with every render.
Wrapped initial index in `Ref` so it stays unchanged during the whole component lifecycle.

**Motivation**

Android version of `react-native-pager-view` recently changed (callstack/react-native-pager-view#407) handling of the `initialPage` prop.
Previous versions handled initial page on the JS-side during `didMount` lifecycle method so it only ran once.
Now it is handled as native prop and selecting page using tab bar triggers 2 native current page handlers with one of them being not animated. Page transition is not animated at all as a result.
