### PR TITLE
feat: add ability to type tab names with SceneRendererProps

### DIFF
--- a/src/types.tsx
+++ b/src/types.tsx
@@ -31,10 +31,10 @@ export type Layout = {
 
 export type Listener = (value: number) => void;
 
-export type SceneRendererProps = {
+export type SceneRendererProps<TKeys extends string = string> = {
   layout: Layout;
   position: Animated.AnimatedInterpolation;
-  jumpTo: (key: string) => void;
+  jumpTo: (key: TKeys) => void;
 };
 
 export type EventEmitterProps = {


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

**Motivation**

I'd like to add more strength to my typings while using the lib. I don't want to make mistakes while using tab names.


**Test plan**

This is a non breaking change. I can't think of any risk with this.

Here's when I add a type parameter (new behaviour):

![image](https://user-images.githubusercontent.com/6313316/130147530-8730fa01-ad92-4f4a-ba17-4f849fbb2f78.png)

Here's when I don't (same as previous behaviour):

![image](https://user-images.githubusercontent.com/6313316/130147631-99cd0a93-8fe1-4a22-b8e0-865b5678500a.png)

Thank you!