### PR TITLE
fix: fix pager style

### DIFF
--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -141,7 +141,8 @@ export default function TabView<T extends Route>({
 
 const styles = StyleSheet.create({
   pager: {
-    flex: 1,
+    flexGrow: 1,
+    flexShrink: 1,
     overflow: 'hidden',
   },
 });


### PR DESCRIPTION
This PR corrects the style of the "TabView" root component when used with the "react-native-web" package in web applications.

code example
    <TabView
      style={{ height: 250 }}
      {...tabViewProps}
    />

before
![image](https://user-images.githubusercontent.com/46069436/130455340-81c9cb2f-7184-41cc-9482-89db1ff6878a.png)

after
![image](https://user-images.githubusercontent.com/46069436/130453584-12274a85-2ca2-4f36-a3aa-85f77909c100.png)
![image](https://user-images.githubusercontent.com/46069436/130454382-1b6b718b-51d1-47ce-954d-6ae45bf8b581.png)
![image](https://user-images.githubusercontent.com/46069436/130454231-95a974ca-6557-4c16-b17a-05d2afb6b210.png)

