### PR TITLE
Expose the style prop accepted by the Pager component

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,10 @@ Object containing the initial height and width of the screens. Passing this will
 
 Style to apply to the view wrapping each screen. You can pass this to override some default styles such as overflow clipping:
 
+##### `pagerStyle`
+
+Style to apply to the pager view wrapping all the scenes.
+
 ##### `style`
 
 Style to apply to the tab view container.

--- a/src/TabView.tsx
+++ b/src/TabView.tsx
@@ -30,6 +30,7 @@ export type Props<T extends Route> = PagerProps & {
   lazy?: ((props: { route: T }) => boolean) | boolean;
   lazyPreloadDistance?: number;
   sceneContainerStyle?: StyleProp<ViewStyle>;
+  pagerStyle?: StyleProp<ViewStyle>;
   style?: StyleProp<ViewStyle>;
 };
 
@@ -46,6 +47,7 @@ export default function TabView<T extends Route>({
   renderLazyPlaceholder = () => null,
   renderTabBar = (props) => <TabBar {...props} />,
   sceneContainerStyle,
+  pagerStyle,
   style,
   swipeEnabled = true,
   tabBarPosition = 'top',
@@ -84,6 +86,7 @@ export default function TabView<T extends Route>({
         onSwipeStart={onSwipeStart}
         onSwipeEnd={onSwipeEnd}
         onIndexChange={jumpToIndex}
+        style={pagerStyle}
       >
         {({ position, render, addEnterListener, jumpTo }) => {
           // All of the props here must not change between re-renders


### PR DESCRIPTION
Pager component already has a style prop, this just exposes it to the end user

**Motivation**

I have a use case where part of the custom tab bar needed to overlap part of the scene. The only way to do it would be to add a negative top margin to the Pager view, however the style prop that is exposed on the Pager view is not exposed on the TabView so currently I can't achieve this use case.