### PR TITLE
fix Vertical Scrollbar show on Tabbar

### DIFF
--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -357,6 +357,7 @@ export default class TabBar<T extends Route> extends React.Component<
             alwaysBounceHorizontal={false}
             scrollsToTop={false}
             showsHorizontalScrollIndicator={false}
+            showsVerticalScrollIndicator={false}
             automaticallyAdjustContentInsets={false}
             overScrollMode="never"
             contentContainerStyle={[


### PR DESCRIPTION
- Replicated in iOS. When I try scrolling on the tabBar there will be a vertical indicator show on the right side of it.
- This issue happened when I custom the TabBarItem.

<img width="270" alt="Screen Shot 2022-03-27 at 22 02 44" src="https://user-images.githubusercontent.com/29066552/160287714-e3b629c7-3797-4bb8-b564-a07feeb32c13.png">

