### PR TITLE
feat: add index to 'onSwipeEnd' call

### DIFF
--- a/src/PagerViewAdapter.tsx
+++ b/src/PagerViewAdapter.tsx
@@ -83,7 +83,7 @@ export default function PagerViewAdapter<T extends Route>({
 
     switch (pageScrollState) {
       case 'idle':
-        onSwipeEnd?.();
+        onSwipeEnd?.(indexRef.current);
         return;
       case 'dragging': {
         const subscription = offset.addListener(({ value }) => {

--- a/src/PanResponderAdapter.tsx
+++ b/src/PanResponderAdapter.tsx
@@ -196,7 +196,7 @@ export default function PanResponderAdapter<T extends Route>({
   ) => {
     panX.flattenOffset();
 
-    onSwipeEnd?.();
+    onSwipeEnd?.(navigationStateRef.current.index);
 
     const currentIndex =
       typeof pendingIndexRef.current === 'number'

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -54,5 +54,5 @@ export type PagerProps = Omit<
   keyboardDismissMode?: 'none' | 'on-drag' | 'auto';
   swipeEnabled?: boolean;
   onSwipeStart?: () => void;
-  onSwipeEnd?: () => void;
+  onSwipeEnd?: (index: number) => void;
 };


### PR DESCRIPTION
**Motivation**

Having the index passed to the `onSwipeEnd` call allows us to use the latest index after the swipe event. This is useful if you keep the index state in your application and want to avoid rendering issues (animation and wrong tab selection) if you update it using the `onIndexChange` callback

**Test plan**

Add the `onSwipeEnd` call and make sure it's showing the correct value. It should be called after `onIndexChange` and it should have the same index number