### PR TITLE
fix: next.js init error.

### DIFF
--- a/src/PanResponderAdapter.tsx
+++ b/src/PanResponderAdapter.tsx
@@ -271,13 +271,13 @@ export default function PanResponderAdapter<T extends Route>({
   const translateX = React.useMemo(() => {
     if (maxTranslate <= 0) return 0;
     return Animated.multiply(
-    panX.interpolate({
-      inputRange: [-maxTranslate, 0],
-      outputRange: [-maxTranslate, 0],
-      extrapolate: "clamp",
-    }),
-    I18nManager.isRTL ? -1 : 1
-   );
+      panX.interpolate({
+        inputRange: [-maxTranslate, 0],
+        outputRange: [-maxTranslate, 0],
+        extrapolate: 'clamp',
+      }),
+      I18nManager.isRTL ? -1 : 1
+    );
   }, [maxTranslate, panX]);
 
   return children({

--- a/src/PanResponderAdapter.tsx
+++ b/src/PanResponderAdapter.tsx
@@ -268,14 +268,17 @@ export default function PanResponderAdapter<T extends Route>({
   });
 
   const maxTranslate = layout.width * (routes.length - 1);
-  const translateX = Animated.multiply(
+  const translateX = React.useMemo(() => {
+    if (maxTranslate <= 0) return 0;
+    return Animated.multiply(
     panX.interpolate({
       inputRange: [-maxTranslate, 0],
       outputRange: [-maxTranslate, 0],
-      extrapolate: 'clamp',
+      extrapolate: "clamp",
     }),
     I18nManager.isRTL ? -1 : 1
-  );
+   );
+  }, [maxTranslate, panX]);
 
   return children({
     position: layout.width

--- a/src/TabBar.tsx
+++ b/src/TabBar.tsx
@@ -141,6 +141,9 @@ export default class TabBar<T extends Route> extends React.Component<
     tabWidths: { [key: string]: number },
     flattenedWidth: string | number | undefined
   ) => {
+    if (routes.length === 0) {
+      return 0;
+    }
     if (flattenedWidth === 'auto') {
       return tabWidths[routes[index].key] || 0;
     }


### PR DESCRIPTION
Please provide enough information so that others can review your pull request: 

**Motivation** 

get this error info when use `React Native` + `Next.js`: 
![image](https://user-images.githubusercontent.com/37520667/171985857-6bc18fcd-5dcf-400a-9dc5-68ab10fcaed3.png)


Explain the **motivation** for making this change. What existing problem does the pull request solve?

- Fix the case where the width is 0 when `next.js` is initialized.

**Test plan**
- Check if the TabView load.



