### PR TITLE
fix: move onIndexChange

### DIFF
--- a/src/PanResponderAdapter.tsx
+++ b/src/PanResponderAdapter.tsx
@@ -81,6 +81,8 @@ export default function PanResponderAdapter<T extends Route>({
 
       const { timing, ...transitionConfig } = DefaultTransitionSpec;
 
+      onIndexChangeRef.current(index);
+
       Animated.parallel([
         timing(panX, {
           ...transitionConfig,
@@ -89,7 +91,6 @@ export default function PanResponderAdapter<T extends Route>({
         }),
       ]).start(({ finished }) => {
         if (finished) {
-          onIndexChangeRef.current(index);
           pendingIndexRef.current = undefined;
         }
       });


### PR DESCRIPTION
**Motivation**

According to this comment https://github.com/satya164/react-native-tab-view/issues/1306#issuecomment-1058763296 This PR just changes the place of onIndexChange method.